### PR TITLE
Fix stripe dependency version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,7 +129,7 @@
     "@storyblok/react": "4.6.1",
     "@stripe/firestore-stripe-payments": "0.0.6",
     "@stripe/react-stripe-js": "2.9.0",
-    "@stripe/stripe-js": "5.0.0",
+    "@stripe/stripe-js": "4.10.0",
     "@suiet/wallet-kit": "0.3.3",
     "@supabase/auth-ui-react": "0.4.7",
     "@supabase/auth-ui-shared": "0.1.8",


### PR DESCRIPTION
## Summary
- resolve npm peer dependency error by downgrading `@stripe/stripe-js`

## Testing
- `make` *(fails: Cannot find module '...types
Patch ..'* due to missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68768b9624088322a5656e9a465b90c7