### PR TITLE
Fix Python runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "src": "backend/main.py",
       "use": "@vercel/python",
       "config": {
-        "runtime": "python3.10"
+        "runtime": "python3.11"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- set Python runtime to 3.11 so `databutton` installs correctly

## Testing
- `npm test` *(fails: Missing script)*
- `python3.11 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6876b82961288322a796ba03d551112d